### PR TITLE
Refactor js into static, move template to base.html, added claude response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Others
+.DS_Store

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -29,10 +29,13 @@ def generate_response(user_input):
 def generate_dll_page():
     if request.method == 'POST':
         user_input = request.json.get('requirements')
+        content_prompt = request.json.get('content_prompt', '')
 
-        result = generate_ai_response(user_input)
+        print(user_input, content_prompt)
+        openai = generate_ai_response(user_input, content_prompt)
+        claude = generate_claude_response(user_input, content_prompt)
         return jsonify({
-            'openai': result,
-            'claude': ''
+            'openai': openai,
+            'claude': claude
         })
     return render_template('generate_ddl.html')

--- a/app/llms/claude.py
+++ b/app/llms/claude.py
@@ -8,7 +8,10 @@ claude_client = anthropic.Anthropic(api_key=api_key)
 
 base_prompt = "You are an SQL Expert. You are asked to write SQL queries based on the prompts given to you. Your response should be a valid SQL query."
 
-def generate_claude_response(prompt):
+def generate_claude_response(prompt: str, content_prompt: str='') -> str:
+    if content_prompt:
+        base_prompt = content_prompt
+    print(f'claude content prompt: {content_prompt} | claude prompt: {prompt}')
     messages = [{"role": "user", "content": prompt}]
     response = claude_client.messages.create(model="claude-3-opus-20240229", max_tokens=300, system=base_prompt, messages=messages)
     return response.content[0].text

--- a/app/llms/openai.py
+++ b/app/llms/openai.py
@@ -8,10 +8,26 @@ api_key = os.getenv('OPENAI_API_KEY')  # Use getenv instead of environ.get
 client = OpenAI(api_key=api_key)
 
 # Setup base prompt
-base_prompt = {"role": "system", "content": "You are an SQL Expert. You are asked to write SQL queries based on the prompts given to you. Your response should be a valid SQL query."}
+base_prompt = {
+    "role": "system", 
+    "content": ("You are an SQL Expert. You are asked to write SQL"
+                "queries based on the prompts given to you. Your "
+                "response should be a valid SQL query.")
+}
 
-def generate_ai_response(prompt):
-    messages = [base_prompt]
+def generate_ai_response(prompt: str, content_prompt: str='') -> str:
+    """
+    args:
+        prompt (str): String to send to openai endpoint
+        content_prompt (str, optional): Custom base prompt content
+    returns:
+        str: Response in markdown from AI
+    """
+    messages = [{
+        'role': 'system',
+        'content': content_prompt
+    } if content_prompt else base_prompt]
+    print(f'openai content prompt: {content_prompt} | openai prompt: {prompt}')
     messages.append({"role": "user", "content": prompt})
     response = client.chat.completions.create(model="gpt-3.5-turbo", messages=messages)  # Use ChatCompletion.create
     return response.choices[0].message.content

--- a/app/static/js/generate_ddl.js
+++ b/app/static/js/generate_ddl.js
@@ -1,0 +1,51 @@
+window.addEventListener('load', () => {
+    hljs.highlightAll();
+})
+
+function cleanResponse(string) {
+    let newStr = [];
+    for (let match of string.matchAll(/(?:```sql\n)([\s\S]*?)(?:```)/g)) {
+        let [_, matchStr] = match;
+        newStr.push(matchStr);
+    }
+    return newStr.join('\n');
+}
+
+async function handleSubmit(e) {
+    e.preventDefault();
+    let requirements = document.getElementById('requirements').value;
+    let content_prompt = document.getElementById('contentPrompt').value;
+
+    console.log(requirements, content_prompt);
+    let dlls = await fetch('/generate_ddl', {
+        method: 'POST',
+        body: JSON.stringify({
+            requirements,
+            content_prompt
+        }),
+        headers: {
+            'Content-type': 'application/json'
+        }
+    }).then(data => data.json());
+    
+    let {openai, claude} = dlls;
+
+    let openaiResp = document.getElementById('openaiResponse');
+    openaiResp.removeAttribute('data-highlighted');
+    openaiResp.textContent = cleanResponse(openai);
+
+    let claudeResp = document.getElementById('claudeResponse');
+    claudeResp.removeAttribute('data-highlighted');
+    claudeResp.textContent = cleanResponse(claude);
+
+    document.getElementById('resultDiv').classList.remove('d-none');
+    hljs.highlightAll();
+}
+
+async function copySQL(e) {
+    let location = e.dataset.location;
+    let ele = document.getElementById(location);
+    if (ele === undefined) return;
+
+    await navigator.clipboard.writeText(ele.textContent);
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+</head>
+<body>
+    {% block body %}
+    {% endblock%}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/app/templates/generate_ddl.html
+++ b/app/templates/generate_ddl.html
@@ -5,9 +5,6 @@
 {% block body %}
 <div class="container mt-2">
     <div class="row">
-        
-    </div>
-    <div class="row">
         <form class="form w-100" onsubmit="return handleSubmit(event)">
             <label for="requirements"><h3>Requirements</h3></label>
             <div class="accordion my-2" id="accordionDiv">

--- a/app/templates/generate_ddl.html
+++ b/app/templates/generate_ddl.html
@@ -1,75 +1,75 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>DDL comparison</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-</head>
-<body>
-    <div class="container mt-2">
-        <div class="row">
-            <form class="form w-100" onsubmit="return handleSubmit(event)">
-                <label for="requirements">Requirements</label>
-                <textarea name="requirements" id="requirements" rows="5" class="form-control"></textarea>
-                
-                <button class="btn btn-primary my-2">Submit</button>
-            </form> 
+{% extends "base.html" %}
+
+{% block title %}DDL comparison{% endblock %}
+
+{% block body %}
+<div class="container mt-2">
+    <div class="row">
+        
+    </div>
+    <div class="row">
+        <form class="form w-100" onsubmit="return handleSubmit(event)">
+            <label for="requirements"><h3>Requirements</h3></label>
+            <div class="accordion my-2" id="accordionDiv">
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                      <button 
+                        class="accordion-button collapsed" 
+                        type="button" 
+                        data-bs-toggle="collapse" 
+                        data-bs-target="#contentPromptBody" 
+                        aria-expanded="false" 
+                        aria-controls="contentPromptBody">
+                        Content Prompt (if any)
+                      </button>
+                    </h2>
+                    <div 
+                        id="contentPromptBody" 
+                        class="accordion-collapse collapse" 
+                        data-bs-parent="#accordionDiv"
+                    >
+                      <div class="accordion-body">
+                        <textarea id="contentPrompt" class="form-control"></textarea>
+                      </div>
+                    </div>
+                </div>
+            </div>
+            <label for="requirements">Prompt requirement</label>
+            <textarea name="requirements" id="requirements" rows="5" class="form-control"></textarea>
+            
+            <button class="btn btn-primary my-2">Submit</button>
+        </form> 
+    </div>
+    <div id="resultDiv" class="row d-none">
+        <div class="col-md-6">
+            <b>Open AI</b>
+            <button class="btn pb-3" onclick="copySQL(this)" data-location='openaiResponse'>
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard" viewBox="0 0 16 16" style="position: relative; right: 0px; top: 0px">
+                <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z"></path>
+                <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z"></path>
+              </svg>
+            </button>
+            <pre>
+                <code 
+                    id='openaiResponse' 
+                    code='language-sql'
+                    class='hljs language-sql'
+                ></code>
+            </pre>
         </div>
-        <div class="row">
-            <div class="col-md-6">
-                <h3>Open AI</h3>
-                <pre>
-                    <code 
-                        id='openaiResponse' 
-                        code='language-sql'
-                        class='hljs language-sql'
-                    ></code>
-                </pre>
-            </div>
-            <div class="col-md-6">
-                <h3>Claude</h3>
-                <pre>
-                    <code id='claudeResponse' code="language-sql" class='hljs language-sql'></code>
-                </pre>
-            </div>
+        <div class="col-md-6">
+            <b>Claude</b>
+            <button class="btn pb-3" onclick="copySQL(this)" data-location='claudeResponse'>
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard" viewBox="0 0 16 16" style="position: relative; right: 0px; top: 0px">
+                <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z"></path>
+                <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z"></path>
+              </svg>
+            </button>
+            <pre>
+                <code id='claudeResponse' code="language-sql" class='hljs language-sql'></code>
+            </pre>
         </div>
     </div>
-    <script>
-        hljs.highlightAll();
-
-        async function handleSubmit(e) {
-            e.preventDefault();
-            let requirements = document.getElementById('requirements').value;
-            console.log(requirements);
-            let dlls = await fetch('/generate_ddl', {
-                method: 'POST',
-                body: JSON.stringify({
-                    'requirements': requirements
-                }),
-                headers: {
-                    'Content-type': 'application/json'
-                }
-            }).then(data => data.json());
-            let {openai, claude} = dlls;
-            console.log(dlls);
-
-            let openaiDDL = '';
-            for (let match of openai.matchAll(/(?:```sql)?\n([\s\S]*?)(?:```)/g)) {
-                let [_, matchStr] = match;
-                openaiDDL += '\n' + matchStr;
-            }
-            console.log(openaiDDL);
-            document.getElementById('openaiResponse').removeAttribute('data-highlighted')
-            document.getElementById('openaiResponse').textContent = openaiDDL;
-
-            hljs.highlightAll();
-            // document.getElementById('claudeResponse').innerText = claude;
-        }   
-    </script>
-</body>
-</html>
+</div>
+<script src="{{url_for('static', filename='js/generate_ddl.js')}}"></script>
+{% endblock %}


### PR DESCRIPTION
Changes
- Inline JS is now moved to static/js folder
- Templates can now inherit from base.html (where bootstrap imports + highlight js imports are)
- Claude responses added
- Quick copy SQL for reference
- Added content / prefix prompt text area to allow changes in schema

<img width="1165" alt="Screenshot 2024-03-18 at 9 16 45 PM" src="https://github.com/joenzkc/cs4221-llm-comparer/assets/24652052/b5967db9-bc25-48d5-9491-89e10776b373">
